### PR TITLE
Login via HTTPS (https://www.di.fm/login)

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -10,7 +10,7 @@ cacheChannels       = cacheChannels.json
 
 [urls]
 frontpage 		    = http://www.di.fm
-login               = http://www.di.fm/login
+login               = https://www.di.fm/login
 listenkey   	    = http://www.di.fm/member/listen_key
 apiAuthenticate     = https://api.audioaddict.com/v1/di/members/authenticate
 


### PR DESCRIPTION
Hi!

When logging into DI the username and password are transmitted in the POST request. 

So it's better to login via HTTPS instead of HTTP to protect the sensitive information.

Regards,
Thomas
