### PR TITLE
Fixed streams for non premium

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.audio.di.fm"
        name="Digitally Imported"
-       version="3.1.0"
+       version="3.1.0.1"
        provider-name="qualisoft.dk - Tim C. Steinmetz">
 	<requires>
 		<import addon="xbmc.python" version="2.1.0"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,9 @@
 * Fixed/improved feature
 - Removed feature
 
+22. January 2016 v3.1.0.1
+* Fixed Streams for non premium
+
 
 25. March 2015 v3.1.0
 + Got a baby daughter - Ella :D

--- a/config.ini
+++ b/config.ini
@@ -1,8 +1,9 @@
 # DI.fm Kodi config
 [plugin]
 id                  = plugin.audio.di.fm
-date                = 25. March 2015
+date                = 22. January 2016
 checkinkey          = a57ab7ceada3fefeaa70a7136ab05f9af5ebac82
+agent               = Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:26.0) Gecko/20100101 Firefox/26.0
 
 [cache]
 cachePremiumConfig  = cachePremiumConfig.json

--- a/default.py
+++ b/default.py
@@ -144,7 +144,7 @@ class musicAddonXbmc:
             html = ""
 
             # if username is set, try to login and go for premium channels
-            if ADDON.getSetting('username') != "":
+            if ADDON.getSetting('username') != "" and ADDON.getSetting('ispremium') == "true":
                 loginData = urllib.urlencode({'member_session[username]': ADDON.getSetting('username'),
                                               'member_session[password]': ADDON.getSetting('password')})
 
@@ -193,10 +193,14 @@ class musicAddonXbmc:
 
             # go for free/public channels
             else:
-                html = self.curler.request(pluginConfig.get('urls', 'frontpage'), 'get')
+                loginData = urllib.urlencode({'member_session[username]': ADDON.getSetting('username'),
+                                              'member_session[password]': ADDON.getSetting('password')})
+
+                # post login info and get frontpage html
+                html = self.curler.request(pluginConfig.get('urls', 'login'), 'post', loginData)
 
                 # if we could not reach di.fm at all
-                if not html:
+                if not bool(html):
                     xbmc.log(u'di.fm could not be reached', xbmc.LOGWARNING)
                     xbmcgui.Dialog().ok(ADDON.getLocalizedString(30100),
                                         ADDON.getLocalizedString(30101),
@@ -208,6 +212,12 @@ class musicAddonXbmc:
                 # put each playlist in a worker queue for threading
                 channels = json.loads(self.curler.request(pluginConfig.get('streams', 'public'), 'get'))
                 channelMeta = self.getChannelMetadata(html)
+
+                premiumConfig = self.getPremiumConfig()
+
+                # add listenkey to playlist urls
+                for channel in channels:
+                    channel['playlist'] = '%s?%s' % (channel['playlist'], premiumConfig['listenKey'] )
 
             for channel in channels:
                 self.workQueue.put(channel)
@@ -269,7 +279,7 @@ class musicAddonXbmc:
 
         # Will get JSON with all channel metadata
         re_channelMeta = re.compile(r"di.app.start\(({.+(?!\}\)))\)", re.M | re.I)
-        
+
         channelMeta = re_channelMeta.findall(html)[0]
 
         # removes those pesky \u2019 and what not
@@ -290,6 +300,8 @@ class musicAddonXbmc:
     def addChannel(self, channel, channelMeta, channelCount):
         # set to true if new channelart is downloaded
         isNew = 0
+        agent = pluginConfig.get('plugin', 'agent')
+        referer = pluginConfig.get('urls', 'frontpage')
 
         # if channel asset does not exist, download it
         if not os.path.exists(self.addonProfilePath + str(channel['key']) + '.png'):
@@ -301,7 +313,7 @@ class musicAddonXbmc:
         if ADDON.getSetting('randomstream') == "true":
             playlist = self.curler.request(channel['playlist'] + self.listenKey, 'get')
             playlistStreams = self.re_playlistStreams.findall(playlist)
-            streamUrl = playlistStreams[randrange(len(playlistStreams))][0]
+            streamUrl = playlistStreams[randrange(len(playlistStreams))][0] + '|User-Agent=' + agent + '&Referer=' + referer
         else:
             streamUrl = channel['playlist'] + self.listenKey
 

--- a/httpcomm.py
+++ b/httpcomm.py
@@ -31,6 +31,7 @@ class HTTPComm:
             ('Keep-Alive', '115'),
             ('Connection', 'keep-alive'),
             ('Cache-Control', 'max-age=0'),
+            ('Referer', 'http://www.di.fm/')
         ]
 
         try:

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -8,10 +8,11 @@
 	<string id="30030">Use first stream for each channel (starts playing faster)</string>
 	<string id="30012">Stream cache expiration in days (0 = never)</string>
 	<string id="30010">Force cache refresh (use when changing settings)</string>
-    <string id="30031">Download random stream from each channel (faster after caching)</string>
+  <string id="30031">Download random stream from each channel (faster after caching)</string>
 
 	<string id="30001">Stream source</string>
 
+  <string id="30183">Login</string>
 	<string id="30002">Premium</string>
 	<string id="30003">E-mail/username</string>
 	<string id="30004">Password</string>
@@ -43,7 +44,7 @@
 	<string id="30100">Connection error</string>
 	<string id="30101">Could not connect to di.fm</string>
 	<string id="30102">Check your internet connection</string>
-    <string id="30103">and the website in your browser</string>
+  <string id="30103">and the website in your browser</string>
 
 	<string id="30110">No streams found</string>
 	<string id="30111">Maybe your DI Premium membership expired?</string>
@@ -68,18 +69,18 @@
 	<string id="30152"> piece(s) of channelart missing</string>
 	<string id="30153">You should refresh your cache</string>
 	<string id="30154">Disable using 'My Favorites' to get new channelart</string>
-	
+
 	<string id="30160">Problem downloading channelart</string>
 	<string id="30161">There was a problem downloading channelart for: </string>
 	<string id="30162">From URL: </string>
 
-    <string id="30170">Login failed</string>
-    <string id="30171">Invalid Username or Password</string>
-    <string id="30172">Has your account perhaps expired?</string>
+  <string id="30170">Login failed</string>
+  <string id="30171">Invalid Username or Password</string>
+  <string id="30172">Has your account perhaps expired?</string>
 
-    <string id="30180">No favorites found</string>
-    <string id="30181">Login to di.fm in your browser and go to 'Manage favorites'</string>
-    <string id="30182">or uncheck 'Use my favorites' from this plugins settings</string>
+  <string id="30180">No favorites found</string>
+  <string id="30181">Login to di.fm in your browser and go to 'Manage favorites'</string>
+  <string id="30182">or uncheck 'Use my favorites' from this plugins settings</string>
 
 
 </strings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -8,9 +8,10 @@
 		<setting id="getpremium" type="lsep" label="30015" />
 	</category>
 
-	<category label="30002">
+	<category label="30183">
 		<setting id="username" type="text" label="30003" />
 		<setting id="password" type="text" option="hidden" label="30004" />
+		<setting id="ispremium" type="bool" label="30002" default="false" />
 		<setting id="bitrate" type="enum" label="30013" values="40|64|128|320" default="4" />
 		<setting id="usefavorites" type="bool" label="30005" default="false" />
 		<setting id="forceupdate" type="bool" label="30010" default="false" />


### PR DESCRIPTION
DI implemented some changes which would only allow playback of the streams on their webpage or within their mobile apps.

This PR should fix this:

Premium is now a toogle in Login section, Username/Password required all the time to get listenKey.
Also User-Agent and Referer needs to be included in the StreamURL.